### PR TITLE
Fix regular expression for extracting container IP address

### DIFF
--- a/main.go
+++ b/main.go
@@ -142,7 +142,7 @@ func getLabelValue(container types.ContainerJSON, predicate predicate) (string, 
 var isServiceName predicate = func(k string) bool { return k == serviceLabelKey }
 var isTaskArn predicate = func(k string) bool { return k == taskArnLabelKey }
 
-var ipRegex = regexp.MustCompile(`"IPv4Addresses":\s*\[\s*"(.+)"\]`)
+var ipRegex = regexp.MustCompile(`"IPv4Addresses":\s*\[\s*"([^"]+)"\]`)
 
 func getContainerIp(containerID string) (string, error) {
 	// ifconfig docker0 | grep -oP 'inet addr:\K\S+'


### PR DESCRIPTION
#### Description

Tighten up the regex used to get the IP address. If you run multiple container definitions, the JSON result has more than one entry and the resulting value spans a section of the JSON.

![image](https://user-images.githubusercontent.com/19393946/39145722-9ca01818-4702-11e8-8d3b-df75649d9039.png)

This is what we should be picking up:

![image](https://user-images.githubusercontent.com/19393946/39145729-a170aa2e-4702-11e8-9dfa-e5b2d6d9025a.png)
